### PR TITLE
Add clustering-based superblock algorithm

### DIFF
--- a/src/road_network.py
+++ b/src/road_network.py
@@ -260,6 +260,35 @@ class RoadNetwork:
 
         logging.info(f"Assigned blocks to superblocks. Total assigned blocks: {len(self.blocks)}")
 
+    def cluster_superblocks(self, capacity_quantile=0.75, min_cluster_size=5, alpha=1.5):
+        """Identify superblocks using clustering of high-capacity edge nodes.
+
+        This method is an alternative to :meth:`assign_blocks_to_superblocks` and
+        relies on :func:`superblock_algorithms.compute_superblocks_by_clustering`.
+
+        Parameters
+        ----------
+        capacity_quantile : float, optional
+            Quantile for selecting high-capacity edges, by default 0.75.
+        min_cluster_size : int, optional
+            Minimum cluster size for HDBSCAN, by default 5.
+        alpha : float, optional
+            Alpha parameter for the alphashape algorithm, by default 1.5.
+        """
+        from .superblock_algorithms import compute_superblocks_by_clustering
+
+        if self.boundary_streets is None:
+            raise ValueError("Streets must be classified before clustering.")
+
+        logging.info("Clustering high-capacity streets to generate superblocks...")
+        self.superblocks = compute_superblocks_by_clustering(
+            self.boundary_streets,
+            capacity_quantile=capacity_quantile,
+            min_cluster_size=min_cluster_size,
+            alpha=alpha,
+        )
+        logging.info(f"Generated {len(self.superblocks)} clustered superblocks.")
+
     def assign_unassigned_blocks(self, unassigned):
         """
         Assigns blocks not within any superblock to the nearest superblock.

--- a/src/superblock_algorithms.py
+++ b/src/superblock_algorithms.py
@@ -1,0 +1,87 @@
+import logging
+import numpy as np
+import geopandas as gpd
+from shapely.geometry import Point
+import hdbscan
+import alphashape
+
+
+def compute_superblocks_by_clustering(
+    gdf_edges: gpd.GeoDataFrame,
+    capacity_quantile: float = 0.75,
+    min_cluster_size: int = 5,
+    alpha: float = 1.5,
+) -> gpd.GeoDataFrame:
+    """Identify superblocks using HDBSCAN clustering and alphashape.
+
+    Parameters
+    ----------
+    gdf_edges : GeoDataFrame
+        Edges with geometries and a 'capacity' column.
+    capacity_quantile : float, optional
+        Quantile threshold to select high-capacity edges, by default 0.75.
+    min_cluster_size : int, optional
+        Minimum cluster size for HDBSCAN, by default 5.
+    alpha : float, optional
+        Alpha parameter for ``alphashape.alphashape``, by default 1.5.
+
+    Returns
+    -------
+    GeoDataFrame
+        GeoDataFrame containing polygons representing superblocks.
+    """
+    if 'capacity' not in gdf_edges.columns:
+        raise ValueError("gdf_edges must contain a 'capacity' column")
+
+    logging.info("Selecting high-capacity edges for clustering...")
+    threshold = gdf_edges['capacity'].quantile(capacity_quantile)
+    high_cap_edges = gdf_edges[gdf_edges['capacity'] >= threshold]
+    logging.info(
+        f"Using capacity threshold {threshold:.2f} (quantile {capacity_quantile})"
+    )
+
+    if high_cap_edges.empty:
+        logging.warning("No edges above the capacity threshold were found.")
+        return gpd.GeoDataFrame(columns=['geometry'], crs=gdf_edges.crs)
+
+    logging.info("Extracting edge nodes for clustering...")
+    points: list[Point] = []
+    for geom in high_cap_edges.geometry:
+        if geom.geom_type == 'LineString':
+            coords = list(geom.coords)
+            points.append(Point(coords[0]))
+            points.append(Point(coords[-1]))
+        elif geom.geom_type == 'MultiLineString':
+            for line in geom.geoms:
+                coords = list(line.coords)
+                points.append(Point(coords[0]))
+                points.append(Point(coords[-1]))
+
+    if not points:
+        logging.warning("No points extracted from high-capacity edges.")
+        return gpd.GeoDataFrame(columns=['geometry'], crs=gdf_edges.crs)
+
+    coords = np.array([(p.x, p.y) for p in points])
+    logging.info("Clustering nodes with HDBSCAN...")
+    clusterer = hdbscan.HDBSCAN(min_cluster_size=min_cluster_size)
+    labels = clusterer.fit_predict(coords)
+
+    polygons = []
+    for label in set(labels):
+        if label == -1:
+            continue  # noise
+        cluster_points = [p for p, l in zip(points, labels) if l == label]
+        if len(cluster_points) < 3:
+            continue
+        poly = alphashape.alphashape(cluster_points, alpha)
+        if poly.is_empty:
+            continue
+        polygons.append(poly)
+
+    logging.info(f"Generated {len(polygons)} superblock polygons from clusters")
+    if not polygons:
+        return gpd.GeoDataFrame(columns=['geometry'], crs=gdf_edges.crs)
+
+    gdf = gpd.GeoDataFrame({'geometry': polygons}, crs=gdf_edges.crs)
+    gdf['superblock_id'] = range(len(gdf))
+    return gdf


### PR DESCRIPTION
## Summary
- implement `compute_superblocks_by_clustering` for finding superblocks from
  high‑capacity edges using HDBSCAN and alphashape
- expose new `RoadNetwork.cluster_superblocks` method

## Testing
- `python -m py_compile src/superblock_algorithms.py src/road_network.py`

------
https://chatgpt.com/codex/tasks/task_e_686a7b000a70832c8da8b4583bdec8af