### PR TITLE
Add modularity-based superblock method and test

### DIFF
--- a/src/road_network.py
+++ b/src/road_network.py
@@ -298,6 +298,35 @@ class RoadNetwork:
         )
         logging.info(f"Generated {len(self.superblocks)} clustered superblocks.")
 
+    def modularity_superblocks(self, capacity_quantile=0.75, resolution=1.0, alpha=1.5):
+        """Identify superblocks using community detection based on modularity.
+
+        This method mirrors :meth:`cluster_superblocks` but relies on
+        :func:`superblock_algorithms.compute_superblocks_by_modularity`.
+
+        Parameters
+        ----------
+        capacity_quantile : float, optional
+            Quantile for selecting high-capacity edges, by default ``0.75``.
+        resolution : float, optional
+            Resolution parameter for modularity optimisation, by default ``1.0``.
+        alpha : float, optional
+            Alpha parameter for the alphashape algorithm, by default ``1.5``.
+        """
+        from superblock_algorithms import compute_superblocks_by_modularity
+
+        if self.boundary_streets is None:
+            raise ValueError("Streets must be classified before community detection.")
+
+        logging.info("Detecting superblocks via modularity-based communities...")
+        self.superblocks = compute_superblocks_by_modularity(
+            self.boundary_streets,
+            capacity_quantile=capacity_quantile,
+            resolution=resolution,
+            alpha=alpha,
+        )
+        logging.info(f"Generated {len(self.superblocks)} modularity superblocks.")
+
     def assign_unassigned_blocks(self, unassigned):
         """
         Assigns blocks not within any superblock to the nearest superblock.

--- a/src/superblock_algorithms.py
+++ b/src/superblock_algorithms.py
@@ -2,7 +2,6 @@ import logging
 import numpy as np
 import geopandas as gpd
 from shapely.geometry import Point
-import hdbscan
 import alphashape
 
 
@@ -63,6 +62,7 @@ def compute_superblocks_by_clustering(
 
     coords = np.array([(p.x, p.y) for p in points])
     logging.info("Clustering nodes with HDBSCAN...")
+    import hdbscan
     clusterer = hdbscan.HDBSCAN(min_cluster_size=min_cluster_size)
     labels = clusterer.fit_predict(coords)
 

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,33 @@
+# Proposed Tasks
+
+The following tasks capture features and improvements that are referenced in the repository but are not yet implemented or complete.
+
+1. **Integrate Real-Time Traffic Data**
+   - Extend the project to pull real-world traffic volumes from an external API.
+   - Update the road network graph with this data and adjust capacity calculations accordingly.
+   - Provide configuration for API keys and document usage.
+
+2. **Optimize Superblock Boundaries**
+   - Develop algorithms to refine superblock polygons for better accessibility and connectivity.
+   - Consider pedestrian and cycling routes when adjusting boundaries.
+   - Expose parameters so users can tune optimization goals.
+
+3. **Run Comprehensive Traffic Simulations**
+   - Implement simulation modules to quantify environmental and social impacts of proposed superblocks.
+   - Incorporate metrics such as congestion, emissions, and travel times.
+   - Present results through reports or interactive visualizations.
+
+4. **Utilize Modularity-Based Superblock Detection**
+   - Connect `compute_superblocks_by_modularity` from `superblock_algorithms.py` into the main `RoadNetwork` workflow.
+   - Create a method similar to `cluster_superblocks` that invokes the modularity approach.
+   - Add tests covering this new method.
+
+5. **High‑Resolution Map Tiling**
+   - Activate the unused `num_tiles` parameter in `wireframe_test.py` to export large maps by stitching tiles.
+   - Document the feature and ensure existing scripts can opt into tile-based exports.
+
+6. **Improve Test Environment Setup**
+   - Simplify running tests by mocking heavy dependencies like `geopandas` or providing lightweight fixtures.
+   - Update CI configuration to install required packages so `pytest` succeeds.
+
+

--- a/tests/test_modularity.py
+++ b/tests/test_modularity.py
@@ -1,0 +1,30 @@
+import sys
+sys.path.append('src')
+
+import geopandas as gpd
+from shapely.geometry import LineString
+from road_network import RoadNetwork
+
+
+def build_simple_boundary():
+    lines = [
+        LineString([(0, 0), (2, 0)]),
+        LineString([(2, 0), (2, 2)]),
+        LineString([(2, 2), (0, 2)]),
+        LineString([(0, 2), (0, 0)]),
+        LineString([(4, 0), (6, 0)]),
+        LineString([(6, 0), (6, 2)]),
+        LineString([(6, 2), (4, 2)]),
+        LineString([(4, 2), (4, 0)]),
+    ]
+    gdf = gpd.GeoDataFrame({'geometry': lines, 'capacity': [1]*len(lines)}, crs='EPSG:4326')
+    return gdf
+
+
+def test_modularity_superblocks_returns_polygons():
+    rn = RoadNetwork('test')
+    rn.boundary_streets = build_simple_boundary()
+    rn.modularity_superblocks(capacity_quantile=0.0)
+    assert rn.superblocks is not None
+    assert not rn.superblocks.empty
+    assert 'geometry' in rn.superblocks.columns


### PR DESCRIPTION
## Summary
- extend `RoadNetwork` with `modularity_superblocks`
- import `hdbscan` lazily to avoid heavy dependency for modularity-based logic
- test the new modularity workflow

## Testing
- `pytest -q` *(fails: numpy.dtype size changed, may indicate binary incompatibility)*

------
https://chatgpt.com/codex/tasks/task_e_686ae3546fdc832c9a0f75de2438e984